### PR TITLE
Adding Caller Id Features

### DIFF
--- a/rc2-dvm/VirtualChannel.P25.cs
+++ b/rc2-dvm/VirtualChannel.P25.cs
@@ -498,6 +498,7 @@ namespace rc2_dvm
                 
                 // Start source ID display callback
                 lastSourceId = e.SrcId;
+                dvmRadio.Status.CallerId = lastSourceId.ToString();
                 // sourceIdTimer.Start();
                 // Start RX data timeout timer
                 rxDataTimer.Start();

--- a/rc2-dvm/VirtualChannel.P25.cs
+++ b/rc2-dvm/VirtualChannel.P25.cs
@@ -531,6 +531,7 @@ namespace rc2_dvm
                 dvmRadio.Status.ChannelName = CurrentTalkgroup.Name;
                 // Stop RX data timeout timer
                 rxDataTimer.Stop();
+                dvmRadio.Status.CallerId = "";
                 // Status update
                 dvmRadio.StatusCallback();
                 // Log

--- a/rc2-dvm/VirtualChannel.P25.cs
+++ b/rc2-dvm/VirtualChannel.P25.cs
@@ -499,7 +499,6 @@ namespace rc2_dvm
                 // Start source ID display callback
                 lastSourceId = e.SrcId;
                 dvmRadio.Status.CallerId = lastSourceId.ToString();
-                // sourceIdTimer.Start();
                 // Start RX data timeout timer
                 rxDataTimer.Start();
                 // Status update
@@ -528,7 +527,6 @@ namespace rc2_dvm
                 // Update state
                 dvmRadio.Status.State = rc2_core.RadioState.Idle;
                 // Stop source ID callback
-                // sourceIdTimer.Stop();
                 dvmRadio.Status.ChannelName = CurrentTalkgroup.Name;
                 // Stop RX data timeout timer
                 rxDataTimer.Stop();

--- a/rc2-dvm/VirtualChannel.P25.cs
+++ b/rc2-dvm/VirtualChannel.P25.cs
@@ -498,7 +498,7 @@ namespace rc2_dvm
                 
                 // Start source ID display callback
                 lastSourceId = e.SrcId;
-                sourceIdTimer.Start();
+                // sourceIdTimer.Start();
                 // Start RX data timeout timer
                 rxDataTimer.Start();
                 // Status update
@@ -527,7 +527,7 @@ namespace rc2_dvm
                 // Update state
                 dvmRadio.Status.State = rc2_core.RadioState.Idle;
                 // Stop source ID callback
-                sourceIdTimer.Stop();
+                // sourceIdTimer.Stop();
                 dvmRadio.Status.ChannelName = CurrentTalkgroup.Name;
                 // Stop RX data timeout timer
                 rxDataTimer.Stop();

--- a/rc2-dvm/VirtualChannel.cs
+++ b/rc2-dvm/VirtualChannel.cs
@@ -311,7 +311,7 @@ namespace rc2_dvm
         {
             Log.Logger.Warning("RX data timeout, resetting call");
             resetCall();
-        //}
+        }
 
         /// <summary>
         /// Start the virtual channel

--- a/rc2-dvm/VirtualChannel.cs
+++ b/rc2-dvm/VirtualChannel.cs
@@ -58,7 +58,7 @@ namespace rc2_dvm
         // Variables for displaying active source ID
         private bool showingSourceId;
         private uint lastSourceId;
-        // private System.Timers.Timer sourceIdTimer;
+
 
         private DVMRadio dvmRadio;
 
@@ -185,10 +185,7 @@ namespace rc2_dvm
                 
             }
 
-            // Init source ID display stuff
-            //sourceIdTimer = new System.Timers.Timer(1000);
-            //sourceIdTimer.Elapsed += sourceIdTimerCallback;
-            //sourceIdTimer.Enabled = true;
+
 
             // Init rx data timeout timer
             rxDataTimer = new System.Timers.Timer(1000);
@@ -281,26 +278,6 @@ namespace rc2_dvm
             dvmRadio.Status.ChannelName = CurrentTalkgroup.Name;
         }
 
-        /// <summary>
-        /// Callback to alternate between TG name and source ID
-        /// </summary>
-        /// <param name="source"></param>
-        /// <param name="e"></param>
-        //private void sourceIdTimerCallback(Object source, ElapsedEventArgs e)
-        //{
-        //    if (showingSourceId)
-        //    {
-        //        dvmRadio.Status.ChannelName = CurrentTalkgroup.Name;
-        //        dvmRadio.StatusCallback();
-        //        showingSourceId = false;
-        //    }
-        //    else
-        //    {
-        //        //dvmRadio.Status.ChannelName = $"ID: {lastSourceId}";
-        //        dvmRadio.StatusCallback();
-        //        showingSourceId = true;
-        //    }
-        //}
 
         /// <summary>
         /// Function called when the rx data timeout timer is hit, will force-reset the call data on loss of LDUs
@@ -500,8 +477,6 @@ namespace rc2_dvm
         /// </summary>
         private void resetCall()
         {
-            // Stop source ID callback
-            // sourceIdTimer.Stop();
             // Stop rx data timeout timer
             rxDataTimer.Stop();
             // Reset P25 counter

--- a/rc2-dvm/VirtualChannel.cs
+++ b/rc2-dvm/VirtualChannel.cs
@@ -58,7 +58,7 @@ namespace rc2_dvm
         // Variables for displaying active source ID
         private bool showingSourceId;
         private uint lastSourceId;
-        private System.Timers.Timer sourceIdTimer;
+        // private System.Timers.Timer sourceIdTimer;
 
         private DVMRadio dvmRadio;
 
@@ -501,7 +501,7 @@ namespace rc2_dvm
         private void resetCall()
         {
             // Stop source ID callback
-            sourceIdTimer.Stop();
+            // sourceIdTimer.Stop();
             // Stop rx data timeout timer
             rxDataTimer.Stop();
             // Reset P25 counter

--- a/rc2-dvm/VirtualChannel.cs
+++ b/rc2-dvm/VirtualChannel.cs
@@ -186,8 +186,8 @@ namespace rc2_dvm
             }
 
             // Init source ID display stuff
-            sourceIdTimer = new System.Timers.Timer(1000);
-            sourceIdTimer.Elapsed += sourceIdTimerCallback;
+            //sourceIdTimer = new System.Timers.Timer(1000);
+            //sourceIdTimer.Elapsed += sourceIdTimerCallback;
             //sourceIdTimer.Enabled = true;
 
             // Init rx data timeout timer
@@ -286,21 +286,21 @@ namespace rc2_dvm
         /// </summary>
         /// <param name="source"></param>
         /// <param name="e"></param>
-        private void sourceIdTimerCallback(Object source, ElapsedEventArgs e)
-        {
-            if (showingSourceId)
-            {
-                dvmRadio.Status.ChannelName = CurrentTalkgroup.Name;
-                dvmRadio.StatusCallback();
-                showingSourceId = false;
-            }
-            else
-            {
-                dvmRadio.Status.ChannelName = $"ID: {lastSourceId}";
-                dvmRadio.StatusCallback();
-                showingSourceId = true;
-            }
-        }
+        //private void sourceIdTimerCallback(Object source, ElapsedEventArgs e)
+        //{
+        //    if (showingSourceId)
+        //    {
+        //        dvmRadio.Status.ChannelName = CurrentTalkgroup.Name;
+        //        dvmRadio.StatusCallback();
+        //        showingSourceId = false;
+        //    }
+        //    else
+        //    {
+        //        //dvmRadio.Status.ChannelName = $"ID: {lastSourceId}";
+        //        dvmRadio.StatusCallback();
+        //        showingSourceId = true;
+        //    }
+        //}
 
         /// <summary>
         /// Function called when the rx data timeout timer is hit, will force-reset the call data on loss of LDUs
@@ -311,7 +311,7 @@ namespace rc2_dvm
         {
             Log.Logger.Warning("RX data timeout, resetting call");
             resetCall();
-        }
+        //}
 
         /// <summary>
         /// Start the virtual channel


### PR DESCRIPTION
This pull request focuses on deprecating the `sourceIdTimer` functionality in the `VirtualChannel` class. The changes involve commenting out all references to `sourceIdTimer`, effectively disabling its initialization, usage, and callback logic. Additionally, a minor update ensures the `CallerId` field is reset during state updates. Below is a breakdown of the most important changes:

### Deprecation of `sourceIdTimer` functionality:

* Commented out the initialization of `sourceIdTimer` and its associated callback (`sourceIdTimerCallback`) in the `VirtualChannel` constructor to prevent it from being set up (`rc2-dvm/VirtualChannel.cs`, [rc2-dvm/VirtualChannel.csL189-R190](diffhunk://#diff-836a3165d7ffd058f959f051e9eff6681a9b0de110c63b88eb68274d182c87a8L189-R190)).
* Disabled the `sourceIdTimerCallback` method by commenting out its implementation, removing the alternating display of the source ID and talkgroup name (`rc2-dvm/VirtualChannel.cs`, [rc2-dvm/VirtualChannel.csL289-R303](diffhunk://#diff-836a3165d7ffd058f959f051e9eff6681a9b0de110c63b88eb68274d182c87a8L289-R303)).
* Commented out all calls to `sourceIdTimer.Start()` and `sourceIdTimer.Stop()` in the `P25DataReceived` method and `resetCall` method to stop triggering the timer (`rc2-dvm/VirtualChannel.P25.cs`, [[1]](diffhunk://#diff-42f67f35b8a63427d1bfe3f9cc4dd23313674f37781bd81a1335b614ce1dbaf3L501-R501) [[2]](diffhunk://#diff-42f67f35b8a63427d1bfe3f9cc4dd23313674f37781bd81a1335b614ce1dbaf3L530-R534); `rc2-dvm/VirtualChannel.cs`, [[3]](diffhunk://#diff-836a3165d7ffd058f959f051e9eff6681a9b0de110c63b88eb68274d182c87a8L504-R504).
* Commented out the `sourceIdTimer` declaration to indicate it is no longer in use (`rc2-dvm/VirtualChannel.cs`, [rc2-dvm/VirtualChannel.csL61-R61](diffhunk://#diff-836a3165d7ffd058f959f051e9eff6681a9b0de110c63b88eb68274d182c87a8L61-R61)).

### State management improvement:

* Added a line to reset `dvmRadio.Status.CallerId` to an empty string during state updates in the `P25DataReceived` method, ensuring the caller ID is cleared when transitioning to an idle state (`rc2-dvm/VirtualChannel.P25.cs`, [rc2-dvm/VirtualChannel.P25.csL530-R534](diffhunk://#diff-42f67f35b8a63427d1bfe3f9cc4dd23313674f37781bd81a1335b614ce1dbaf3L530-R534)).