### PR TITLE
Fix FNE encryption key loading and request keys for encrypted home channels on startup

### DIFF
--- a/rc2-dvm/PeerSystem.cs
+++ b/rc2-dvm/PeerSystem.cs
@@ -113,7 +113,8 @@ namespace rc2_dvm
 
         protected override void KeyResponse(object sender, KeyResponseEvent e)
         {
-            // Stub
+            // Distribute keys to virtual channels
+            base.KeyResponse(sender, e);
         }
 
         /// <summary>


### PR DESCRIPTION
The `KeyResponse` override in `PeerSystem.cs` was an empty stub that silently discarded all key responses from the FNE. Keys were being requested but never stored, causing `KeyNotFoundException` on encrypted transmit.

Added `base.KeyResponse()` call to actually distribute keys to virtual channels. Also added key request on startup for encrypted home channels so users don't have to switch channels first, and a safety check in `StartTransmit()` to gracefully fail instead of crash if a key isn't loaded.